### PR TITLE
library-field transalign; lz4 compression

### DIFF
--- a/Transalign/Align.hs
+++ b/Transalign/Align.hs
@@ -14,7 +14,7 @@
 {-# Language FlexibleContexts #-}
 {-# LANGUAGE CPP #-}
 
-module Align (A(..),Alignment,score,collect_aligns,merge_aligns) where
+module Transalign.Align (A(..),Alignment,score,collect_aligns,merge_aligns) where
 
 import Control.Applicative ( (<$>) )
 import qualified Data.IntMap.Strict as M

--- a/Transalign/Blast.hs
+++ b/Transalign/Blast.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE CPP #-}
 
 
-module Blast where
+module Transalign.Blast where
 
 import qualified Data.ByteString.Lazy.Char8 as B
 --import qualified Data.ByteString.Char8 as C
@@ -30,9 +30,9 @@ import Debug.Trace
 import Data.Int
 import Text.Printf
 import GHC.Float (double2Float)
-import Align
 
-import TabularBlastParser
+import Transalign.Align
+import Transalign.TabularBlastParser
 
 type BlastAlignData = Alignment Float Int32 Int32
 type BlastAlignment = (B.ByteString,BlastAlignData)

--- a/Transalign/Output.hs
+++ b/Transalign/Output.hs
@@ -1,4 +1,4 @@
-module Output where
+module Transalign.Output where
 
 import qualified Data.ByteString.Lazy.Char8 as B
 import Text.Printf (printf)
@@ -9,8 +9,8 @@ import qualified Data.Vector.Generic as G
 import qualified Data.Vector.Generic.Mutable
 
 
-import Blast (BlastAlignData, print_alignment)
-import Align (Alignment,score,A(..))
+import Transalign.Blast (BlastAlignData, print_alignment)
+import Transalign.Align (Alignment,score,A(..))
 
 output_long :: B.ByteString -> [(Float,B.ByteString,BlastAlignData)] -> IO ()
 output_long src = do 

--- a/Transalign/TabularBlastParser.hs
+++ b/Transalign/TabularBlastParser.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE LambdaCase #-}
 
 -- This attoparsec module
-module TabularBlastParser (module TabularBlastParser)
-where
+module Transalign.TabularBlastParser where
+
 import Prelude hiding (takeWhile)
 import Data.Attoparsec.ByteString.Char8 hiding (isSpace)
 import qualified Data.Attoparsec.ByteString.Lazy as L
@@ -34,8 +34,9 @@ parseTabularBlasts :: B.ByteString -> [BlastTabularResult]
 parseTabularBlasts = go
   where go xs = case L.parse genParseTabularBlast xs of
           L.Fail remainingInput ctxts err  -> error $ "parseTabularBlasts failed! " ++ err ++ " ctxt: " ++ show ctxts ++ " head of remaining input: " ++ (B.unpack $ B.take 1000 remainingInput)
-          L.Done remainingInput btr ->
-            btr : go remainingInput
+          L.Done remainingInput btr
+            | B.null remainingInput  -> [btr]
+            | otherwise              -> btr : go remainingInput
 
 data BlastTabularResult = BlastTabularResult
   { blastProgram :: !BlastProgram,
@@ -50,10 +51,10 @@ data BlastTabularResult = BlastTabularResult
 data BlastProgram = BlastX | BlastP | BlastN
   deriving (Show, Eq)
 
-genParseTabularBlasts :: Parser [BlastTabularResult]
-genParseTabularBlasts = do
-  bresults <- many1 genParseTabularBlast
-  return bresults
+--genParseTabularBlasts :: Parser [BlastTabularResult]
+--genParseTabularBlasts = do
+--  bresults <- many1 genParseTabularBlast
+--  return bresults
 
 genParseBlastProgram :: Parser BlastProgram
 genParseBlastProgram = do

--- a/src/BlastExtract.hs
+++ b/src/BlastExtract.hs
@@ -1,5 +1,8 @@
-import BlastCache
+module Main where
+
 import System.Environment (getArgs)
+
+import Transalign.BlastCache
 
 main :: IO ()
 main = mapM_ buildCache =<< getArgs

--- a/src/ShowCache.hs
+++ b/src/ShowCache.hs
@@ -1,11 +1,14 @@
-import BlastCache (readAlignmentCache)
-import Blast (print_alignment)
-import Output
+module Main where
 
 import System.Environment (getArgs)
 import System.FilePath (splitFileName)
 import Data.ByteString.Lazy.Char8 (pack)
 import Data.List (partition)
+
+import Transalign.BlastCache (readAlignmentCache)
+import Transalign.Blast (print_alignment)
+import Transalign.Output
+
 
 main :: IO ()
 main = do 

--- a/src/TransAlign.hs
+++ b/src/TransAlign.hs
@@ -16,11 +16,11 @@ import Data.Ord
 import System.Mem (performGC)
 import Control.Parallel.Strategies
 
-import Align (collect_aligns,merge_aligns)
-import Blast (BlastAlignment, BlastAlignData, readAlignments)
-import BlastCache (readAlignmentCache, buildCache)
+import Transalign.Align (collect_aligns,merge_aligns)
+import Transalign.Blast (BlastAlignment, BlastAlignData, readAlignments)
+import Transalign.BlastCache (readAlignmentCache, buildCache)
 import Options (getArgs, Opts(..))
-import Output (output_long, output_short, add_score)
+import Transalign.Output (output_long, output_short, add_score)
 
 main :: IO ()
 main = do

--- a/transalign.cabal
+++ b/transalign.cabal
@@ -11,35 +11,97 @@ Category:            Bioinformatics
 Build-type:          Simple
 Cabal-version:       >=1.10.0
 
-Executable transalign
-   Main-Is:        TransAlign.hs
-   Other-modules:  Align, Blast, BlastCache, Options, Output, TabularBlastParser
-   Hs-Source-Dirs: src
-   Build-Depends:  base >= 3, containers >= 0.5, blastxml >= 0.3, bytestring >= 0.9, binary, directory, deepseq, cmdargs, biocore, vector, vector-th-unbox, template-haskell >= 2.5, vector-algorithms >= 0.6, parallel, hashable, unordered-containers, judy == 0.2.3, filemanip >= 0.3, cassava >= 0.4.5.0, attoparsec >= 0.13.0, filepath, zlib >= 0.6
-   Ghc-Options:  -rtsopts -threaded -Odph -fno-liberate-case -funfolding-use-threshold100 -funfolding-keeness-factor100 -feager-blackholing
+library
+  build-depends: base   >= 4.7
+               , attoparsec
+               , binary
+               , biocore
+               , blastxml
+               , bytestring
+               , cassava
+               , containers
+               , deepseq
+               , directory
+               , filepath
+               , hashable
+               , judy == 0.2.3
+               , parallel
+               , parallel-io >= 0.3.3
+               , split
+               , unordered-containers
+               , vector
+               , vector-algorithms
+               , vector-th-unbox
+               , lz4    >= 0.2
+               , cereal >= 0.5
 
-Executable blastextract
-   Main-Is:        BlastExtract.hs
-   Other-modules:  Align, Blast, BlastCache, TabularBlastParser
-   Hs-Source-Dirs: src
-   Build-Depends:  base >= 3, blastxml >= 0.3, containers >= 0.5, bytestring >= 0.9, binary, directory, deepseq, biocore, vector, vector-th-unbox, template-haskell >= 2.5, vector-algorithms >= 0.6, parallel, hashable, unordered-containers, judy == 0.2.3, filemanip >= 0.3,  cassava >= 0.4.5.0, attoparsec >= 0.13.0, filepath, zlib >= 0.6
-   Ghc-Options:  -rtsopts -threaded -feager-blackholing
+  exposed-modules:
+    Transalign.Align
+    Transalign.Blast
+    Transalign.BlastCache
+    Transalign.Output
+    Transalign.TabularBlastParser
+  default-extensions: BangPatterns
+                    , OverloadedStrings
+  default-language:
+    Haskell2010
+  ghc-options:
+    -O2 -funbox-strict-fields
 
-Executable showcache
-   Main-Is:        ShowCache.hs
-   Other-modules:  Align, Blast, BlastCache, Output, TabularBlastParser
-   Hs-Source-Dirs: src
-   Build-Depends:  base >= 3, blastxml >= 0.3, containers >= 0.5, bytestring >= 0.9, binary, directory, filepath, deepseq, biocore, vector, vector-th-unbox, template-haskell >= 2.5, vector-algorithms >= 0.6, parallel, hashable, unordered-containers, judy == 0.2.3, filemanip >= 0.3,  cassava >= 0.4.5.0, attoparsec >= 0.13.0, filepath, zlib >= 0.6
-   Ghc-Options:  -rtsopts -threaded -feager-blackholing
+executable transalign
+  main-is:        TransAlign.hs
+  other-modules:
+    Options
+  hs-source-dirs: src
 
---Executable transalign_prof
---   Main-Is:        TransAlign.hs
---   Other-modules:  Align, Blast, BlastCache, Output, Options
---   Hs-Source-Dirs: src
---   Build-Depends:  base >= 3, containers >= 0.5, blastxml >= 0.3, bytestring >= 0.9, binary, directory, deepseq, cmdargs, biocore, vector, vector-th-unbox, template-haskell >= 2.5, vector-algorithms >= 0.6, parallel, hashable, unordered-containers, judy == 0.2.3, filemanip >= 0.3,  cassava >= 0.4.5.0, attoparsec >= 0.13.0
---   Ghc-Options:  -prof -fprof-auto-top -rtsopts -threaded -rtsopts -Odph -fno-liberate-case -funfolding-use-threshold100 -funfolding-keeness-factor100 -feager-blackholing
-Library
-  Hs-Source-Dirs:      ./src/
-  ghc-options:         -Wall -O2 -fno-warn-unused-do-bind
-  build-depends:       base >=4.5 && <5, cmdargs, blastxml>=0.3.2, bytestring, vector, attoparsec, directory
-  Exposed-Modules:     TabularBlastParser
+  build-depends: base >= 4.7
+               , cmdargs
+               , parallel
+               , directory
+               , containers
+               , bytestring
+               --
+               , transalign
+
+  ghc-options:
+    -rtsopts
+    -threaded
+    -O2
+    -fno-liberate-case
+    -funfolding-use-threshold100
+    -funfolding-keeness-factor100
+    -feager-blackholing
+
+executable blastextract
+  main-is:        BlastExtract.hs
+  hs-source-dirs: src
+
+  build-depends: base >= 4.7
+               --
+               , transalign
+  ghc-options:
+    -rtsopts
+    -O2
+    -threaded
+    -feager-blackholing
+
+executable showcache
+  main-is:        ShowCache.hs
+  hs-source-dirs: src
+
+  build-depends: base >= 4.7
+               , filepath
+               , bytestring
+               --
+               , transalign
+  ghc-options:
+    -rtsopts
+    -O2
+    -threaded
+    -feager-blackholing
+
+--Library
+--  Hs-Source-Dirs:      ./src/
+--  ghc-options:         -Wall -O2 -fno-warn-unused-do-bind
+--  build-depends:       base >=4.5 && <5, cmdargs, blastxml>=0.3.2, bytestring, vector, attoparsec, directory
+--  Exposed-Modules:     TabularBlastParser


### PR DESCRIPTION
- having transalign as a library is much more pleasant to work with
- lz4 is much faster than gzip
- we should reach about 10-30 mbyte/s in cache preparation, mostly
  waiting for score calculations
- needs parallelization for that now ...